### PR TITLE
Added logic to warehouse_account_asset_aggregates to determine value of invested assets purchased in last two years.

### DIFF
--- a/models/aggregates/warehouse_account_asset_aggregates.sql
+++ b/models/aggregates/warehouse_account_asset_aggregates.sql
@@ -1,7 +1,25 @@
-select customer_code, 
-count(case when invested_value > 0 then customer_code end) as invested_machines,
-sum(value) as total_value, 
-sum(invested_value) as total_invested_value, 
-sum(value) - sum(invested_value) as total_customer_owned_value
-from  {{ref('warehouse_assets')}}
+select 
+
+	a.customer_code, 
+	count(case when a.invested_value > 0 then a.customer_code end) as invested_machines,
+	sum(a.value) as total_value, 
+	sum(a.invested_value) as total_invested_value, 
+	sum(a.value) - sum(a.invested_value) as total_customer_owned_value,
+
+
+	--Minimum weekly sales is partially dependent on the invested value. 
+	--Only assets purchased in the last 2 fiscal years count towards that value. 
+	sum(
+		case 
+			when
+				a.date_purchased is null or 								--NULL values for purchase date are included 
+				(now.fyear = f.fyear) or 										--This fiscal year
+        (now.fyear - 1 = f.fyear) or 								--Last fiscal year
+        (now.fyear - 2 = f.fyear and not f.is_ytd) 	--Two fiscal years ago
+      then a.invested_value
+		end) as invested_value_last_2_years
+
+from  {{ref('warehouse_assets')}} a
+left join analytics_finance.finance_calendar f on date(a.date_purchased) = f.date
+join analytics_finance.finance_calendar now on current_date = now.date
 group by customer_code

--- a/models/tables/warehouse_accounts.sql
+++ b/models/tables/warehouse_accounts.sql
@@ -91,6 +91,7 @@ round((aa.total_coffee_extension / nullif(aa.total_coffee_weight, 0))::decimal(1
 coalesce(aaa.invested_machines,0) as invested_machines,
 coalesce(aaa.total_value, 0) as total_asset_value,
 coalesce(aaa.total_invested_value, 0) as total_invested_asset_value,
+coalesce(aaa.invested_value_last_2_years, 0) as invested_asset_value_last_2_years,
 coalesce(aaa.total_customer_owned_value, 0) as total_customer_owned_asset_value
 
 


### PR DESCRIPTION
Relatively minor changes, but hits on warehouse_accounts table with some new joins upstream, so it warrants a branch.

Goal was to create a new field which would return the value of all invested assets purchased within the last 2 fiscal years, at the customer_code level. This will eventually be used in calculation of a client's minimum weekly sales.

I confirmed there are no changes when comparing the output of this warehouse_accounts model to the currently published analytics_wholesale.accounts table. Row counts are the same, and the total_invested_asset_value amounts are the same. The only change is the creation of a new column.