### PR TITLE
Migrated from 0.20.2 to 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 logs/
 target/
-dbt_modules/
+dbt_packages/

--- a/_gitignore
+++ b/_gitignore
@@ -1,3 +1,3 @@
 logs/
 target/
-dbt_modules/
+dbt_packages/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,12 +3,13 @@ name: 'warehouse'
 
 config-version: 2
 version: '1.0'
+require-dbt-version: ">=1.0.0"
 
-source-paths: ["models"]   # paths with source code to compile
-analysis-paths: ["analysis"] # path with analysis files which are compiled, but not run
+model-paths: ["models"]   # paths with source code to compile
+analysis-paths: ["analyses"] # path with analysis files which are compiled, but not run
 target-path: "target"      # path for compiled code
-clean-targets: ["target"]  # directories removed by the clean task
-test-paths: ["test"]       # where to store test results
-data-paths: ["data"]       # load CSVs from this directory with `dbt seed`
+clean-targets: ["target", "dbt_packages"]  # directories removed by the clean task
+test-paths: ["tests"]       # where to store test results
+seed-paths: ["data"]       # load CSVs from this directory with `dbt seed`
 
 profile: lacolombe-wholesale


### PR DESCRIPTION
https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.0

The only relevant changes for us are in dbt_project.yml file:

- Added explicit version requirement: require-dbt-version: ">=1.0.0"
- source-paths => model-paths
- default test-paths went from test to tests
- default analysis-paths went from analysis to analyses
- data-paths => seed-paths
- dbt_modules => dbt_packages in clean-targets