### PR TITLE
Added revised_requested_delivery_date logic

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -1,5 +1,15 @@
 version: 2
 
+sources:
+  - name: lambda_uploads
+    loader: lambda
+
+    tables:
+
+    - name: wholesale_revised_rdd
+      description: Manual override for requested delivery date. In cases where Tremaine provides a revised RDD for a sales_order_number, this will automatically flow through to all reports in place of the requested_delivery_date. Google Sheet accessible here - https://docs.google.com/spreadsheets/d/1FzyFf-_hSYqSshLnSpHpz2TyuwxhbsXuWyULBbS14dg/edit#gid=0
+
+
 models:
 
   - name: warehouse_invoices

--- a/models/source/mapping/revised_requested_delivery_date.sql
+++ b/models/source/mapping/revised_requested_delivery_date.sql
@@ -1,0 +1,16 @@
+--https://docs.google.com/spreadsheets/d/1FzyFf-_hSYqSshLnSpHpz2TyuwxhbsXuWyULBbS14dg/edit#gid=0
+--Manual overrides for the requested_delivery_date
+
+with recency as (
+  select
+    salesordernumber as sales_order_number,
+    revisedrdd::date as revised_requested_delivery_date,
+    row_number() over(partition by salesordernumber order by row_number desc) as recency
+  from {{source('lambda_uploads','wholesale_revised_rdd')}}
+)
+
+select
+  sales_order_number,
+  revised_requested_delivery_date
+from recency
+where recency = 1

--- a/models/tables/warehouse_invoices.sql
+++ b/models/tables/warehouse_invoices.sql
@@ -11,7 +11,12 @@ SELECT
 	i.header_number,
 	i.invoice_type,
 	i.invoice,
-	i.requested_delivery_date,
+	--Requested delivery date defaults to revised_requested_delivery date when provided. 
+	--If not, and if the shipping_method is CUST PICKUP, returns invocie_date. Otherwise returns requested_delivery_date
+	nvl(
+		rrdd.revised_requested_delivery_date, 
+		case when i.shipping_method = 'CUST PICKUP' then i.invoice_date else i.requested_delivery_date end
+		) as requested_delivery_date,
 	i.ship_date,
 	i.days_until_payment_due,
 	i.discount_rate,
@@ -58,5 +63,6 @@ left join {{ref('warehouse_invoice_aggregates')}} ia on ia.unique_invoice_id = i
 left join {{ref('warehouse_paid_coffee_invoice_ranking')}} pci on pci.unique_invoice_id = i.unique_invoice_id
 left join {{ref('warehouse_invoice_shipment_aggregates')}} s on i.invoice_number = s.invoice_number
 left join {{ref('warehouse_base_accounts')}} a on i.customer_code = a.customer_code
+left join {{ref('revised_requested_delivery_date')}} rrdd on i.sales_order_number = rrdd.sales_order_number
 
 where nvl(ia.total_quantity,0) != 0

--- a/models/tables/warehouse_open_sales_orders.sql
+++ b/models/tables/warehouse_open_sales_orders.sql
@@ -1,11 +1,11 @@
 select 
 
-	sales_order_number, 
+	so.sales_order_number, 
 	line_number,
 	order_date, 
 	order_type,
 	ship_date,
-	requested_delivery_date,
+	nvl(rrdd.revised_requested_delivery_date,requested_delivery_date) as requested_delivery_date,
 	customer_code,
 	customer_purchase_order_number,
 	ship_to_code,
@@ -33,3 +33,4 @@ select
 	gl_account_key
 
 from {{ref('so_sales_orders')}} so
+left join {{ref('revised_requested_delivery_date')}} rrdd on so.sales_order_number = rrdd.sales_order_number

--- a/models/tables/warehouse_sales_orders.sql
+++ b/models/tables/warehouse_sales_orders.sql
@@ -3,7 +3,12 @@ select
   so.unique_sales_order_id,
   so.sales_order_number,
   so.order_date,
-  so.requested_delivery_date,
+  --Requested delivery date defaults to revised_requested_delivery date when provided. 
+  --If not, and if the shipping_method is CUST PICKUP, returns invocie_date. Otherwise returns requested_delivery_date
+  nvl(
+    rrdd.revised_requested_delivery_date, 
+    case when so.ship_via = 'CUST PICKUP' then so.last_invoice_date else so.requested_delivery_date end
+  ) as requested_delivery_date,
   so.last_invoice_date,
   so.order_status,
   so.customer_code,
@@ -37,3 +42,4 @@ select
 
 from {{ref('so_sales_order_history_header')}} so
 left join {{ref('so_sales_order_history_header')}} pso on pso.customer_code = so.customer_code and pso.account_order_number = so.account_order_number - 1
+left join {{ref('revised_requested_delivery_date')}} rrdd on so.sales_order_number = rrdd.sales_order_number


### PR DESCRIPTION
Tremaine needs a way to alter the requested_delivery_date reported from MAS, and also wants the rdd to default to the invoice_date in cases where the shipping method is customer pickup. Revised requested delivery dates are now being captured here:

https://docs.google.com/spreadsheets/d/1FzyFf-_hSYqSshLnSpHpz2TyuwxhbsXuWyULBbS14dg/edit#gid=0

And invoice and sales_orders models were updated with this new logic