### PR TITLE
Moved direct table references to dbt source syntax

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -9,13 +9,109 @@ sources:
     - name: wholesale_revised_rdd
       description: Manual override for requested delivery date. In cases where Tremaine provides a revised RDD for a sales_order_number, this will automatically flow through to all reports in place of the requested_delivery_date. Google Sheet accessible here - https://docs.google.com/spreadsheets/d/1FzyFf-_hSYqSshLnSpHpz2TyuwxhbsXuWyULBbS14dg/edit#gid=0
 
+  - name: sage
+    schema: sage
+    loader: DMS
+
+    tables:
+
+    - name: ap_checkhistorydetail
+    - name: ap_checkhistoryheader
+    - name: ap_invoicehistorydetail
+    - name: ap_invoicehistoryheader
+    - name: ap_openinvoice
+    - name: ap_termscode
+    - name: ap_vendor
+    - name: ar_cashreceiptshistory
+    - name: ar_customer
+    - name: AR_CustomerCreditCard
+    - name: ar_customerdocumentcontacts
+    - name: AR_CustomerPDFLog
+    - name: ar_division
+    - name: ar_invoicehistorydetail
+    - name: ar_invoicehistoryheader
+    - name: ar_openinvoice
+    - name: ar_termscode
+    - name: ar_udt_sls_ccr_am
+    - name: bm_billdetail
+    - name: bm_billheader
+    - name: bm_productionhistorydetail
+    - name: BM_Productionhistoryheader
+    - name: ci_item
+    - name: gl_account
+    - name: gl_accountcategory
+    - name: gl_accountgroup
+    - name: gl_accounttype
+    - name: gl_detailposting
+    - name: im_itemtransactionhistory
+    - name: im_pricecode
+    - name: im_productline
+    - name: im_transactiondetail
+    - name: im_transactionheader 
+    - name: im_warehouse
+    - name: po_purchaseorderdetail
+    - name: po_purchaseorderheader
+    - name: po_receipthistorydetail
+    - name: po_receipthistoryheader
+    - name: so_dailyshipment
+    - name: so_dailyshipmentpackage
+    - name: so_invoicedetail
+    - name: so_invoiceheader 
+    - name: so_packagetrackingbyitem
+    - name: so_salesorderdetail
+    - name: so_salesorderheader
+    - name: so_salesorderhistorydetail
+    - name: so_salesorderhistoryheader
+    - name: so_udt_shipper_checker
+    - name: sy_user
+
+  - name: lcg
+    schema: lcg
+    loader: DMS
+
+    tables:
+
+    - name: ar_invoicehistorydetail
+    - name: ar_invoicehistoryheader
+    - name: so_salesorderhistoryheader
+
+  - name: lct
+    schema: lct
+    loader: DMS
+
+    tables:
+
+    - name: ar_invoicehistorydetail 
+    - name: ar_invoicehistoryheader
+    - name: so_salesorderhistoryheader
+
+  - name: starship
+    schema: starship
+    loader: DMS
+
+    tables:
+
+    - name: shipment
+    - name: shipmentorder
+
+  - name: sysdba
+    schema: sysdba
+    loader: DMS
+
+    tables:
+
+    - name: account
+    - name: accountasset
+    - name: c_account
+    - name: dl_acct_ref
+    - name: userinfo
 
 models:
 
   - name: warehouse_invoices
     columns:
       - name: unique_invoice_id
-        description: Unique identifier at the invoice level. MD5 hash of the schema name (lcg, lch, or lct) || invoiceno || headerseqno from ar_invoice_history_header
+        description: Unique identifier at the invoice level. MD5 hash of the schema name lcg, lch, or lct || invoiceno || headerseqno from ar_invoice_history_header
         tests: 
           - not_null:
               tags: wholesale_tests

--- a/models/source/ap-po/ap_check_detail.sql
+++ b/models/source/ap-po/ap_check_detail.sql
@@ -12,4 +12,4 @@ select
   vendorno as vendor_number,
   comment,
   amountpaid as amount_paid
-from dbo.ap_checkhistorydetail
+from {{source('sage','ap_checkhistorydetail')}}

--- a/models/source/ap-po/ap_check_header.sql
+++ b/models/source/ap-po/ap_check_header.sql
@@ -20,6 +20,6 @@ select
   cu.full_name as created_by,
   dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
   uu.full_name as updated_by
-from dbo.ap_checkhistoryheader ch
+from {{source('sage','ap_checkhistoryheader')}} ch
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key =userupdatedkey

--- a/models/source/ap-po/ap_invoice_history_detail.sql
+++ b/models/source/ap-po/ap_invoice_history_detail.sql
@@ -10,7 +10,7 @@ il.extensionamt as extension,
 p.name as item_name,
 w.warehouse_name,
 a.full_account_number
-from dbo.ap_invoicehistorydetail il
+from {{source('sage','ap_invoicehistorydetail')}} il
 left join {{ref('ci_item')}} p on p.sku = il.itemcode
 left join {{ref('im_warehouse')}} w on w.warehouse_code = il.warehousecode
 left join {{ref('gl_account')}} a on a.id = il.accountkey

--- a/models/source/ap-po/ap_invoice_history_header.sql
+++ b/models/source/ap-po/ap_invoice_history_header.sql
@@ -21,7 +21,7 @@ datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as c
 cu.full_name as created_by,
 dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
 uu.full_name as updated_by
-from dbo.ap_invoicehistoryheader i
+from {{source('sage','ap_invoicehistoryheader')}} i
 left join {{ref('ap_terms')}} t on t.terms_code = i.termscode
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/ap-po/ap_open_invoice.sql
+++ b/models/source/ap-po/ap_open_invoice.sql
@@ -20,7 +20,7 @@ i.datecreated + (nullif(i.timecreated, '')::DECIMAL(7,5) || ' hours')::interval 
 cu.full_name as created_by,
 i.dateupdated + (nullif(i.timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
 uu.full_name as updated_by
-from dbo.ap_openinvoice i
+from {{source('sage','ap_openinvoice')}} i
 left join {{ref('ap_vendor')}} v on v.division = i.apdivisionno and v.vendor_number = i.vendorno
 left join {{ref('sy_user')}} cu on cu.user_key = i.usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = i.userupdatedkey

--- a/models/source/ap-po/ap_vendor.sql
+++ b/models/source/ap-po/ap_vendor.sql
@@ -15,7 +15,7 @@ select
   cu.full_name as created_by,
   dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
   uu.full_name as updated_by
-from dbo.ap_vendor v
+from {{source('sage','ap_vendor')}} v
 left join {{ref('sy_user')}} cu on cu.user_key = v.usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = v.userupdatedkey
 left join {{ref('ap_terms')}} apt on apt.terms_code = v.termscode

--- a/models/source/ap-po/po_purchase_order_detail.sql
+++ b/models/source/ap-po/po_purchase_order_detail.sql
@@ -36,7 +36,7 @@ datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as c
 cu.full_name as created_by,
 dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
 uu.full_name as updated_by
-from dbo.po_purchaseorderheader h
-join dbo.po_purchaseorderdetail d on d.purchaseorderno = h.purchaseorderno
+from {{source('sage','po_purchaseorderheader')}} h
+join {{source('sage','po_purchaseorderdetail')}} d on d.purchaseorderno = h.purchaseorderno
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/ap-po/po_purchase_order_history_receipts.sql
+++ b/models/source/ap-po/po_purchase_order_history_receipts.sql
@@ -19,8 +19,8 @@ datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as c
 cu.full_name as created_by,
 dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
 uu.full_name as updated_by
-from dbo.po_receipthistorydetail d
-join dbo.po_receipthistoryheader h on h.purchaseorderno = d.purchaseorderno and h.headerseqno = d.headerseqno and h.receiptno = d.receiptno
+from {{source('sage','po_receipthistorydetail')}} d
+join {{source('sage','po_receipthistoryheader')}} h on h.purchaseorderno = d.purchaseorderno and h.headerseqno = d.headerseqno and h.receiptno = d.receiptno
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey
 left join {{ref('im_warehouse')}} w on w.warehouse_code = d.warehousecode

--- a/models/source/ar-so/ar_cash_receipts_history.sql
+++ b/models/source/ar-so/ar_cash_receipts_history.sql
@@ -28,6 +28,6 @@ datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as c
 cu.full_name as created_by,
 dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
 uu.full_name as updated_by
-from dbo.ar_cashreceiptshistory
+from {{source('sage','ar_cashreceiptshistory')}}
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/ar-so/ar_customer.sql
+++ b/models/source/ar-so/ar_customer.sql
@@ -77,7 +77,7 @@ c.comment,
 c.contactcode as contact_code
 
 
-from dbo.ar_customer c
+from {{source('sage','ar_customer')}} c
 left join {{ref('ar_terms')}} t on c.termscode = t.terms_code
 left join {{ref('ar_account_ownership')}} sr on c.udf_salesperson = sr.owner_id
 left join {{ref('ar_account_ownership')}} ssr on c.udf_cocreator = ssr.owner_id

--- a/models/source/ar-so/ar_customer_credit_card.sql
+++ b/models/source/ar-so/ar_customer_credit_card.sql
@@ -10,6 +10,6 @@ select
   cu.full_name as created_by,
   dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
   uu.full_name as updated_by
-from dbo.AR_CustomerCreditCard
+from {{source('sage','AR_CustomerCreditCard')}}
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/ar-so/ar_customer_document_contact.sql
+++ b/models/source/ar-so/ar_customer_document_contact.sql
@@ -8,4 +8,4 @@ select
 	  else datecreated::date
   end as created_date
 
-from dbo.ar_customerdocumentcontacts
+from {{source('sage','ar_customerdocumentcontacts')}}

--- a/models/source/ar-so/ar_customer_pdf.sql
+++ b/models/source/ar-so/ar_customer_pdf.sql
@@ -6,5 +6,5 @@ select
     sent = 'Y' as pdf_sent,
     datecreated as pdf_created_at
 
-from dbo.AR_CustomerPDFLog
+from {{source('sage','AR_CustomerPDFLog')}}
 where invoiceno is not null and invoiceno != '' and sequence::int = 0

--- a/models/source/ar-so/ar_invoice_history_detail.sql
+++ b/models/source/ar-so/ar_invoice_history_detail.sql
@@ -24,7 +24,7 @@ from (
     warehousecode as warehouse_code,
     salesacctkey as sales_account_key
     
-  from lct.ar_invoicehistorydetail i
+  from {{source('lct','ar_invoicehistorydetail')}} i
   left join lambda_uploads.historical_sku_mapping sm on sm.oldsku = i.itemcode and sm.database = 'lct'
 
   union all
@@ -48,7 +48,7 @@ from (
     warehousecode as warehouse_code,
     salesacctkey as sales_account_key
     
-  from lcg.ar_invoicehistorydetail 
+  from {{source('lcg','ar_invoicehistorydetail')}} 
 
   union all
 
@@ -71,7 +71,7 @@ from (
     warehousecode as warehouse_code,
     salesacctkey as sales_account_key
     
-  from dbo.ar_invoicehistorydetail 
+  from {{source('sage','ar_invoicehistorydetail')}}
 ) il
 left join {{ref('ci_item')}} p on p.sku = il.sku
 left join {{ref('gl_account')}} a on a.id = il.sales_account_key

--- a/models/source/ar-so/ar_invoice_history_header.sql
+++ b/models/source/ar-so/ar_invoice_history_header.sql
@@ -53,7 +53,7 @@ from (
     null as packed_by,
     null as checked_by
 
-  from lct.ar_invoicehistoryheader i
+  from {{source('lct','ar_invoicehistoryheader')}} i
   left join lambda_uploads.historical_customer_mapping cm on cm.oldcustomercode = i.customerno and cm.database = 'lct'
   left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
   left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey
@@ -111,7 +111,7 @@ from (
     null as packed_by,
     null as checked_by
 
-  from lcg.ar_invoicehistoryheader i
+  from {{source('lcg','ar_invoicehistoryheader')}} i
   left join lambda_uploads.historical_customer_mapping cm on cm.oldcustomercode = i.customerno and cm.database = 'lcg'
   left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
   left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey
@@ -172,7 +172,7 @@ from (
     sh.employee_name as packed_by,
     ch.employee_name as checked_by
 
-  from dbo.ar_invoicehistoryheader i
+  from {{source('sage','ar_invoicehistoryheader')}} i
   left join lambda_uploads.historical_customer_mapping cm on cm.oldcustomercode = i.customerno and cm.database = 'lch'
   left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
   left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/ar-so/ar_open_invoices.sql
+++ b/models/source/ar-so/ar_open_invoices.sql
@@ -20,6 +20,6 @@ datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as c
 cu.full_name as created_by,
 dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
 uu.full_name as updated_by
-from dbo.ar_openinvoice
+from {{source('sage','ar_openinvoice')}}
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/ar-so/slx_account.sql
+++ b/models/source/ar-so/slx_account.sql
@@ -9,4 +9,4 @@ accountmanager as primary_account_manager_name,
 coalesce(regionalmanagerid, '') as regional_manager_id,
 coalesce(divisionalmanagerid, '') as divisional_manager_id
 
-from sysdba.account
+from {{source('sysdba','account')}}

--- a/models/source/ar-so/slx_assets.sql
+++ b/models/source/ar-so/slx_assets.sql
@@ -11,4 +11,4 @@ select
 	A.UserField5 as vendor,
  	A.UserField6 as class,  
 	A.InvestValue as invested_value
-from sysdba.accountasset A
+from {{source('sysdba','accountasset')}} A

--- a/models/source/ar-so/so_daily_shipments.sql
+++ b/models/source/ar-so/so_daily_shipments.sql
@@ -13,4 +13,4 @@ select
   timeupdated as time_updated,
   userupdatedkey as user_updated_key
 
-from dbo.so_dailyshipment
+from {{source('sage','so_dailyshipment')}}

--- a/models/source/ar-so/so_invoice_packages.sql
+++ b/models/source/ar-so/so_invoice_packages.sql
@@ -3,4 +3,4 @@ select
   packageno as package_number,
   trackingid as tracking_id,
   shipvia as shipping_service
-from dbo.so_dailyshipmentpackage
+from {{source('sage','so_dailyshipmentpackage')}}

--- a/models/source/ar-so/so_sales_order_history_detail.sql
+++ b/models/source/ar-so/so_sales_order_history_detail.sql
@@ -12,5 +12,5 @@ d.quantityorderedoriginal as original_quantity,
 d.quantityorderedrevised as revised_quantity,
 d.quantityshipped as shipped_quantity,
 d.quantitybackordered as backordered_quantity
-from dbo.so_salesorderhistorydetail d
+from {{source('sage','so_salesorderhistorydetail')}} d
 left join {{ref('im_warehouse')}} w on w.warehouse_code = d.warehousecode

--- a/models/source/ar-so/so_sales_order_history_header.sql
+++ b/models/source/ar-so/so_sales_order_history_header.sql
@@ -57,7 +57,7 @@ from (
     dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
     uu.full_name as updated_by,
     s.warehousecode as warehouse_code
-  from dbo.so_salesorderhistoryheader s
+  from {{source('sage','so_salesorderhistoryheader')}} s
   left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
   left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey
   where orderstatus in  ('A','C')
@@ -111,7 +111,7 @@ from (
     dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
     uu.full_name as updated_by,
     s.warehousecode as warehouse_code
-  from lcg.so_salesorderhistoryheader s
+  from {{source('lcg','so_salesorderhistoryheader')}} s
   left join lambda_uploads.historical_customer_mapping cm on cm.oldcustomercode = s.customerno and cm.database = 'lcg'
   left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
   left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey
@@ -167,7 +167,7 @@ from (
     dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
     uu.full_name as updated_by,
     s.warehousecode as warehouse_code
-  from lct.so_salesorderhistoryheader s
+  from {{source('lct','so_salesorderhistoryheader')}} s
   left join lambda_uploads.historical_customer_mapping cm on cm.oldcustomercode = s.customerno and cm.database = 'lct'
   left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
   left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/ar-so/so_sales_orders.sql
+++ b/models/source/ar-so/so_sales_orders.sql
@@ -41,8 +41,8 @@ uu.full_name as updated_by,
 h.comment as order_comment,
 d.salesacctkey as gl_account_key
 
-from dbo.so_salesorderheader h
-join dbo.so_salesorderdetail d on d.salesorderno = h.salesorderno
+from {{source('sage','so_salesorderheader')}} h
+join {{source('sage','so_salesorderdetail')}} d on d.salesorderno = h.salesorderno
 left join {{ref('so_sales_order_history_detail')}} hd on d.salesorderno = hd.sales_order_number and d.linekey = hd.line_number
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/ar-so/so_shipment_items.sql
+++ b/models/source/ar-so/so_shipment_items.sql
@@ -8,4 +8,4 @@ select
   aliasitemno as alias_item_number, 
   quantity
 
-from dbo.so_packagetrackingbyitem
+from {{source('sage','so_packagetrackingbyitem')}}

--- a/models/source/ar-so/so_shipment_packages.sql
+++ b/models/source/ar-so/so_shipment_packages.sql
@@ -8,4 +8,4 @@ select
   freightamt as freight_amount, 
   weight
 
-from dbo.so_dailyshipmentpackage
+from {{source('sage','so_dailyshipmentpackage')}}

--- a/models/source/ar-so/so_staged_shipment_items.sql
+++ b/models/source/ar-so/so_staged_shipment_items.sql
@@ -14,4 +14,4 @@ select
   quantityshipped as quantity_shipped,
   quantitybackordered as quantity_backordered
 
-from dbo.so_invoicedetail
+from {{source('sage','so_invoicedetail')}}

--- a/models/source/ar-so/so_staged_shipments.sql
+++ b/models/source/ar-so/so_staged_shipments.sql
@@ -30,4 +30,4 @@ select
   usercreatedkey as user_created_key,
   userupdatedkey as user_updated_key
 
-from dbo.so_invoiceheader    
+from {{source('sage','so_invoiceheader')}}

--- a/models/source/ar-so/starship_shipments.sql
+++ b/models/source/ar-so/starship_shipments.sql
@@ -11,6 +11,6 @@ select
   s.mastertrackingid as tracking_id,
   s.mastertrackinglink as tracking_link,
   s.totalpackqty as number_of_packages
-from starship.shipment s
-  join starship.shipmentorder so on so.shipmentid = s.internalid and so.ordernumber != 'No Order'
+from {{source('starship','shipment')}} s
+  join {{source('starship','shipmentorder')}} so on so.shipmentid = s.internalid and so.ordernumber != 'No Order'
 where deleted = 0

--- a/models/source/gl/gl_entry_detail.sql
+++ b/models/source/gl/gl_entry_detail.sql
@@ -18,5 +18,5 @@ datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as c
 cu.full_name as created_by
 
 
-from dbo.gl_detailposting
+from {{source('sage','gl_detailposting')}}
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey

--- a/models/source/im-bm-ci/bm_detail.sql
+++ b/models/source/im-bm-ci/bm_detail.sql
@@ -6,5 +6,5 @@ i.name as component_name,
 d.quantityperbill as quantity,
 i.unit_cost as component_cost,
 i.unit_of_measure as uom
-from dbo.bm_billdetail d 
+from {{source('sage','bm_billdetail')}} d
 join {{ref('ci_item')}} i on i.sku = d.componentitemcode

--- a/models/source/im-bm-ci/bm_header.sql
+++ b/models/source/im-bm-ci/bm_header.sql
@@ -10,6 +10,6 @@ h.datecreated + (nullif(h.timecreated, '')::DECIMAL(7,5) || ' hours')::interval 
 cu.full_name as created_by,
 h.dateupdated + (nullif(h.timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
 uu.full_name as updated_by
-from dbo.bm_billheader h
+from {{source('sage','bm_billheader')}} h
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/im-bm-ci/bm_production_history_detail.sql
+++ b/models/source/im-bm-ci/bm_production_history_detail.sql
@@ -13,4 +13,4 @@ select
 	d.extendedquantity as total_quantity,
 	d.totalcost as total_cost
 
-from dbo.bm_productionhistorydetail d 
+from {{source('sage','bm_productionhistorydetail')}} d

--- a/models/source/im-bm-ci/bm_production_history_header.sql
+++ b/models/source/im-bm-ci/bm_production_history_header.sql
@@ -14,5 +14,5 @@ select
 	p.datecreated::date as created_at,
 	p.dateupdated::date as updated_at
 
-from dbo.BM_Productionhistoryheader p
+from {{source('sage','BM_Productionhistoryheader')}} p
 

--- a/models/source/im-bm-ci/ci_item.sql
+++ b/models/source/im-bm-ci/ci_item.sql
@@ -23,5 +23,5 @@ pl.returnsacctkey as return_gl_id,
 pl.adjustmentacctkey as adjustment_gl_id,
 pl.purchaseacctkey as purchase_gl_id
 
-from dbo.ci_item i
-left join dbo.im_productline pl on  pl.productline = i.productline
+from {{source('sage','ci_item')}} i
+left join {{source('sage','im_productline')}} pl on  pl.productline = i.productline

--- a/models/source/im-bm-ci/im_item_transactions.sql
+++ b/models/source/im-bm-ci/im_item_transactions.sql
@@ -15,5 +15,5 @@ transactionqty as transaction_quantity,
 transactioncode as transaction_type,
 dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
 uu.full_name as updated_by
-from dbo.im_itemtransactionhistory t
+from {{source('sage','im_itemtransactionhistory')}} t
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/im-bm-ci/im_open_transactions.sql
+++ b/models/source/im-bm-ci/im_open_transactions.sql
@@ -11,8 +11,8 @@ select
   dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
   uu.full_name as updated_by,
   cu.full_name as created_by
-from dbo.im_transactionheader h
-join dbo.im_transactiondetail d on d.entryno = h.entryno
+from {{source('sage','im_transactionheader')}} h
+join {{source('sage','im_transactiondetail')}} d on d.entryno = h.entryno
 join {{ref('im_warehouse')}} fw on fw.warehouse_code = defaultfromwhsecode
 join {{ref('im_warehouse')}} tw on tw.warehouse_code = towhsecode
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey

--- a/models/source/im-bm-ci/im_price_code.sql
+++ b/models/source/im-bm-ci/im_price_code.sql
@@ -14,4 +14,4 @@ select
     when '' then NULL
     else discountmarkup1
   end as contract_price
-from dbo.im_pricecode pc
+from {{source('sage','im_pricecode')}} pc

--- a/models/source/mapping/ap_terms.sql
+++ b/models/source/mapping/ap_terms.sql
@@ -2,4 +2,4 @@ select
   termscode as terms_code,
   termscodedesc as terms_code_description,
   daysbeforedue as days_before_due
-from dbo.ap_termscode
+from {{source('sage','ap_termscode')}}

--- a/models/source/mapping/ar_account_ownership.sql
+++ b/models/source/mapping/ar_account_ownership.sql
@@ -2,4 +2,4 @@ select
     udf_sls_ccr_am_code as owner_id,
     udf_name as user_name
 
-from dbo.ar_udt_sls_ccr_am
+from {{source('sage','ar_udt_sls_ccr_am')}}

--- a/models/source/mapping/ar_division.sql
+++ b/models/source/mapping/ar_division.sql
@@ -5,4 +5,4 @@ case ardivisionno
 	when '20' then 'New York'
 	else ardivisiondesc 
 end as division
-from dbo.ar_division
+from {{source('sage','ar_division')}}

--- a/models/source/mapping/ar_terms.sql
+++ b/models/source/mapping/ar_terms.sql
@@ -4,4 +4,4 @@ termscodedesc as payment_terms,
 daysbeforedue as days_until_payment_due,
 daysbeforediscountdue as days_until_discount_due,
 discountrate as discount_rate
-from dbo.ar_termscode 
+from {{source('sage','ar_termscode')}}

--- a/models/source/mapping/gl_account.sql
+++ b/models/source/mapping/gl_account.sql
@@ -17,7 +17,7 @@ a.accountgroup as group_code,
 a.accountcategory as category_code,
 a.accounttype as type_code
 
-from dbo.gl_account a
-left join dbo.gl_accounttype t on t.accountcategory = a.accountcategory and t.accounttype = a.accounttype
-left join dbo.gl_accountgroup g on g.accountcategory = a.accountcategory and g.accounttype = a.accounttype and g.accountgroup = a.accountgroup
-left join dbo.gl_accountcategory c on c.accountcategory = a.accountcategory
+from {{source('sage','gl_account')}} a
+left join {{source('sage','gl_accounttype')}} t on t.accountcategory = a.accountcategory and t.accounttype = a.accounttype
+left join {{source('sage','gl_accountgroup')}} g on g.accountcategory = a.accountcategory and g.accounttype = a.accounttype and g.accountgroup = a.accountgroup
+left join {{source('sage','gl_accountcategory')}} c on c.accountcategory = a.accountcategory

--- a/models/source/mapping/im_warehouse.sql
+++ b/models/source/mapping/im_warehouse.sql
@@ -13,4 +13,4 @@ case warehousedesc
 	when 'Allendale Warehouse' then 'Allendale'
 	else warehousedesc
 end as warehouse_name
-from dbo.im_warehouse w
+from {{source('sage','im_warehouse')}} w

--- a/models/source/mapping/slx_account_ref.sql
+++ b/models/source/mapping/slx_account_ref.sql
@@ -5,5 +5,5 @@ max(accountid) as account_id,
 max(acct_division) as division,
 max(comp_code) as company_code
 
-from sysdba.dl_acct_ref dl
+from {{source('sysdba','dl_acct_ref')}} dl
 group by 1

--- a/models/source/mapping/slx_c_account.sql
+++ b/models/source/mapping/slx_c_account.sql
@@ -10,4 +10,4 @@ customertype as group_code,
 newminvol as min_vol,
 newtier as new_tier
 
-from sysdba.c_account 
+from {{source('sysdba','c_account')}}

--- a/models/source/mapping/slx_users.sql
+++ b/models/source/mapping/slx_users.sql
@@ -6,4 +6,4 @@ select distinct
     username as full_name,
     title
 
-from sysdba.userinfo 
+from {{source('sysdba','userinfo')}}

--- a/models/source/mapping/so_udt_shipper_checker.sql
+++ b/models/source/mapping/so_udt_shipper_checker.sql
@@ -2,4 +2,4 @@ select
   udf_shipper_checker_code as shipper_checker_code,
   udf_active as active,
   udf_ship_check_name as employee_name
-from dbo.so_udt_shipper_checker
+from {{source('sage','so_udt_shipper_checker')}}

--- a/models/source/mapping/sy_user.sql
+++ b/models/source/mapping/sy_user.sql
@@ -6,4 +6,4 @@ select
   lastname as last_name,
   firstname || ' ' || lastname as full_name,
   active
-from dbo.sy_user
+from {{source('sage','sy_user')}}


### PR DESCRIPTION
In preparation for Sage upgrade, we replaced all table references in models previously formatted like <schema>.<table> to instead use DBT's source syntax, like {{source('<schema>','<table>')}}, and updated the schema.yml file to support this change.

This impacted how we reference the dbo, sysdba, starship, lct, and lcg schemas in all warehouse models.

The only schema name changing in this migration is dbo, which will now point to the sage schema.