### PR TITLE
Deprecated warehouse code 038 in favor of 049

### DIFF
--- a/models/source/ap-po/ap_invoice_history_detail.sql
+++ b/models/source/ap-po/ap_invoice_history_detail.sql
@@ -1,16 +1,35 @@
+with ap_invoice_history_detail as (
+	select
+		invoiceno as invoice_number,
+		headerseqno as header_sequence_number,
+		detailseqno as line_number,
+		accountkey as account_key,
+		--Warehouse 038 and 049 both represent the same Garfield location. 038 is deprecated in favor of 049
+		case warehousecode 
+			when '038' then '049' 
+			else warehousecode 
+		end as warehouse_code,	
+		itemcode as sku,
+		quantityordered as quantity_ordered,
+		quantityreceived as quantity_received,
+		quantityinvoiced as quantity_invoiced,
+		extensionamt as extension
+	from {{source('sage','ap_invoicehistorydetail')}}
+)
+
 select
-il.invoiceno as invoice_number,
-il.headerseqno as header_sequence_number,
-il.detailseqno as line_number,
-il.itemcode as sku,
-il.quantityordered as quantity_ordered,
-il.quantityreceived as quantity_received,
-il.quantityinvoiced as quantity_invoiced,
-il.extensionamt as extension,
-p.name as item_name,
-w.warehouse_name,
-a.full_account_number
-from {{source('sage','ap_invoicehistorydetail')}} il
-left join {{ref('ci_item')}} p on p.sku = il.itemcode
-left join {{ref('im_warehouse')}} w on w.warehouse_code = il.warehousecode
-left join {{ref('gl_account')}} a on a.id = il.accountkey
+	il.invoice_number,
+	il.header_sequence_number,
+	il.line_number,
+	il.sku,
+	il.quantity_ordered,
+	il.quantity_received,
+	il.quantity_invoiced,
+	il.extension,
+	p.name as item_name,
+	w.warehouse_name,
+	a.full_account_number
+from ap_invoice_history_detail il
+left join {{ref('ci_item')}} p using(sku)
+left join {{ref('im_warehouse')}} w using(warehouse_code)
+left join {{ref('gl_account')}} a on a.id = il.account_key

--- a/models/source/ap-po/po_purchase_order_detail.sql
+++ b/models/source/ap-po/po_purchase_order_detail.sql
@@ -1,8 +1,8 @@
 select 
-h.purchaseorderno as purchase_order_number,
-h.purchaseorderdate as purchase_order_date,
-d.linekey as line_number,
-h.orderstatus as order_status,
+  h.purchaseorderno as purchase_order_number,
+  h.purchaseorderdate as purchase_order_date,
+  d.linekey as line_number,
+  h.orderstatus as order_status,
   case lastinvoicedate 
     when '1753-01-01' then null
     else lastinvoicedate::date
@@ -19,23 +19,27 @@ h.orderstatus as order_status,
     when '1753-01-01' then null
     else lastreceiptdate::date
   end as last_receipt_date, 
-d.extensionamt as extension,
-d.quantityordered as quantity_ordered,
-d.quantityinvoiced as quantity_invoiced,
-d.quantityreceived as quantity_received,
-d.originalunitcost as original_unit_cost,
-d.itemcodedesc as item_name,
-d.unitcost as invoiced_unit_cost,
-d.itemcode as sku,
-h.apdivisionno as division,
-h.vendorno as vendor_id,
-h.comment as comment,
-h.ordertype as order_type,
-h.warehousecode as warehouse_code,
-datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as created_at,
-cu.full_name as created_by,
-dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
-uu.full_name as updated_by
+  d.extensionamt as extension,
+  d.quantityordered as quantity_ordered,
+  d.quantityinvoiced as quantity_invoiced,
+  d.quantityreceived as quantity_received,
+  d.originalunitcost as original_unit_cost,
+  d.itemcodedesc as item_name,
+  d.unitcost as invoiced_unit_cost,
+  d.itemcode as sku,
+  h.apdivisionno as division,
+  h.vendorno as vendor_id,
+  h.comment as comment,
+  h.ordertype as order_type,
+  --Warehouse 038 and 049 both represent the same Garfield location. 038 is deprecated in favor of 049
+  case h.warehousecode 
+    when '038' then '049' 
+    else h.warehousecode 
+  end as warehouse_code,  
+  datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as created_at,
+  cu.full_name as created_by,
+  dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
+  uu.full_name as updated_by
 from {{source('sage','po_purchaseorderheader')}} h
 join {{source('sage','po_purchaseorderdetail')}} d on d.purchaseorderno = h.purchaseorderno
 left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey

--- a/models/source/ap-po/po_purchase_order_history_receipts.sql
+++ b/models/source/ap-po/po_purchase_order_history_receipts.sql
@@ -1,26 +1,44 @@
+with po_receipthistorydetail as (
+	select
+		headerseqno,
+		receipttype as receipt_type,
+		receiptno as receipt_number,
+		linekey as purchase_order_line_number,
+		purchaseorderno as purchase_order_number,
+		--Warehouse 038 and 049 both represent the same Garfield location. 038 is deprecated in favor of 049
+	  case warehousecode 
+	    when '038' then '049' 
+	    else warehousecode 
+	  end as warehouse_code,  
+		itemcode as sku,
+		quantityreceived * (case unitofmeasureconvfactor when 0 then 1 else unitofmeasureconvfactor end) as quantity,
+		quantityreceived as quantity_in_ordered_uom
+	from {{source('sage','po_receipthistorydetail')}}
+)
+
 select 
-d.receipttype as receipt_type,
-d.receiptno as receipt_number,
-linekey as purchase_order_line_number,
-d.purchaseorderno as purchase_order_number,
-itemcode as sku,
-  case receiptdate 
-    when '1753-01-01' then null
-    else receiptdate::date
-  end as recieved_at,
-  case h.transactiondate
-	when '1753-01-01' then null
-	else h.transactiondate::date
-  end as transaction_date,
-quantityreceived * (case unitofmeasureconvfactor when 0 then 1 else unitofmeasureconvfactor end) as quantity,
-quantityreceived as quantity_in_ordered_uom,
-w.warehouse_name as warehouse,
-datecreated + (nullif(timecreated, '')::DECIMAL(7,5) || ' hours')::interval as created_at,
-cu.full_name as created_by,
-dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
-uu.full_name as updated_by
-from {{source('sage','po_receipthistorydetail')}} d
-join {{source('sage','po_receipthistoryheader')}} h on h.purchaseorderno = d.purchaseorderno and h.headerseqno = d.headerseqno and h.receiptno = d.receiptno
-left join {{ref('sy_user')}} cu on cu.user_key = usercreatedkey
-left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey
-left join {{ref('im_warehouse')}} w on w.warehouse_code = d.warehousecode
+	d.receipt_type,
+	d.receipt_number,
+	d.purchase_order_line_number,
+	d.purchase_order_number,
+	d.sku,
+	case h.receiptdate 
+		when '1753-01-01' then null
+		else h.receiptdate::date
+	end as recieved_at,
+	case h.transactiondate
+		when '1753-01-01' then null
+		else h.transactiondate::date
+	end as transaction_date,
+	d.quantity,
+	d.quantity_in_ordered_uom,
+	w.warehouse_name as warehouse,
+	h.datecreated + (nullif(h.timecreated, '')::DECIMAL(7,5) || ' hours')::interval as created_at,
+	cu.full_name as created_by,
+	h.dateupdated + (nullif(h.timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
+	uu.full_name as updated_by
+from po_receipthistorydetail d
+join {{source('sage','po_receipthistoryheader')}} h on h.purchaseorderno = d.purchase_order_number and h.headerseqno = d.headerseqno and h.receiptno = d.receipt_number
+left join {{ref('sy_user')}} cu on cu.user_key = h.usercreatedkey
+left join {{ref('sy_user')}} uu on uu.user_key = h.userupdatedkey
+left join {{ref('im_warehouse')}} w on w.warehouse_code = d.warehouse_code

--- a/models/source/im-bm-ci/im_item_transactions.sql
+++ b/models/source/im-bm-ci/im_item_transactions.sql
@@ -1,19 +1,23 @@
 select
-entryno as entry_number,
-customerno as customer_code,
-itemcode as sku,
-warehousecode as warehouse_code,
-case transactiondate 
-	when '1753-01-01' then null
-	else transactiondate::date
-end as transaction_date, 
-case referencedate 
-	when '1753-01-01' then null
-	else referencedate::date
-end as sent_date, 
-transactionqty as transaction_quantity,
-transactioncode as transaction_type,
-dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
-uu.full_name as updated_by
+	entryno as entry_number,
+	customerno as customer_code,
+	itemcode as sku,
+	--Warehouse 038 and 049 both represent the same Garfield location. 038 is deprecated in favor of 049
+	case warehousecode 
+	  when '038' then '049' 
+	  else warehousecode 
+	end as warehouse_code,  
+	case transactiondate 
+		when '1753-01-01' then null
+		else transactiondate::date
+	end as transaction_date, 
+	case referencedate 
+		when '1753-01-01' then null
+		else referencedate::date
+	end as sent_date, 
+	transactionqty as transaction_quantity,
+	transactioncode as transaction_type,
+	dateupdated + (nullif(timeupdated, '')::DECIMAL(7,5) || ' hours')::interval as updated_at,
+	uu.full_name as updated_by
 from {{source('sage','im_itemtransactionhistory')}} t
 left join {{ref('sy_user')}} uu on uu.user_key = userupdatedkey


### PR DESCRIPTION
warehouse_code 038 and 049 were created for the same location by mistake. Both warehouse codes have transactions logged against them, but they should all be logged under the same warehouse_code.

Goal of this PR is to merge the two warehouses at the source layer, deprecating 038 in favor of 049.

https://lacolombedata.zendesk.com/agent/tickets/925