### PR TITLE
updating slx account ref to assets only

### DIFF
--- a/models/source/mapping/slx_account_ref.sql
+++ b/models/source/mapping/slx_account_ref.sql
@@ -1,9 +1,17 @@
-select distinct
-
-acct_id as customer_code,
-max(accountid) as account_id,
-max(acct_division) as division,
-max(comp_code) as company_code
+with assetonly as
+(select accountid,
+count(aa.accountid) as asset_rows
 
 from {{source('sysdba','dl_acct_ref')}} dl
+left join {{source('sysdba','accountasset')}} aa using(accountid)
 group by 1
+having asset_rows >= 1)
+
+select distinct
+acct_id as customer_code,
+accountid as account_id,
+acct_division as division,
+comp_code as company_code
+
+from {{source('sysdba','dl_acct_ref')}} dl
+    join assetonly ao using(accountid)


### PR DESCRIPTION
The old slx account query would arbitrarily take the max account id from slx, meaning it would sometimes pull the wrong one. We changed the query to pull in only accounts with assets. 