### PR TITLE
add kit type to open sales orders

### DIFF
--- a/models/source/ar-so/so_sales_orders.sql
+++ b/models/source/ar-so/so_sales_orders.sql
@@ -28,6 +28,10 @@ w.warehouse_name as warehouse,
 currentinvoiceno as invoice_number,
 d.itemcode as sku,
 d.itemcodedesc as item_name,
+case when d.saleskitlinekey != '' and d.saleskitlinekey = d.linekey then 'Parent'
+  when d.saleskitlinekey != '' and d.saleskitlinekey != d.linekey then 'Child'
+  else 'Non Kit'
+end as kit_type,
 d.pricelevel as price_level,
 d.quantityordered as quantity_ordered,
 hd.original_quantity as quantity_original,

--- a/models/tables/warehouse_open_sales_orders.sql
+++ b/models/tables/warehouse_open_sales_orders.sql
@@ -19,6 +19,7 @@ select
 	invoice_number,
 	sku,
 	item_name,
+  kit_type,
 	price_level,
 	quantity_ordered,
 	quantity_original,


### PR DESCRIPTION
We already added kit type to invoices and sales orders, we also want to include this in open sales orders. 