### PR TITLE
cutting over segment field to new customer_type_name udf

### DIFF
--- a/models/source/ar-so/ar_customer.sql
+++ b/models/source/ar-so/ar_customer.sql
@@ -39,13 +39,7 @@ primaryshiptocode as primary_ship_to,
 taxschedule as tax,
 pricelevel as price_tier,
 sortfield as ar_bucket,
-case udf_customer_type
-  when '1' then 'Standard Hospitality'
-  when '2' then 'Foodservice'
-  when '3' then 'National'
-  when '4' then 'Large Format'
-  else udf_customer_type 
-end as segment,
+ct.udf_customer_type_name as segment,
 case customerstatus
   when 'A' then 'Active'
   when 'I' then 'Inactive'
@@ -84,3 +78,4 @@ left join {{ref('ar_terms')}} t on c.termscode = t.terms_code
 left join {{ref('ar_account_ownership')}} sr on c.udf_salesperson = sr.owner_id
 left join {{ref('ar_account_ownership')}} ssr on c.udf_cocreator = ssr.owner_id
 left join {{ref('ar_account_ownership')}} am on c.udf_account_manager = am.owner_id
+left join {{ref('ar_udt_customer_type')}} ct on c.udf_customer_type = ct.udf_customer_type_code


### PR DESCRIPTION
Updating segment field to look at the customer_type_name udf from the ar_customer_type udt. It is currently is hardcoded to only look the udf_customer_type field associated with hospitality.  The plan here is to make the cutover to the new udt in the source model so the the existing segment field won't be impacted upstream. Segment will split into Segment(Hospitality) and CPG Channel(CPG) in the materialized layer. 