### PR TITLE
Updatated invoice filter for new Forge deductions

### DIFF
--- a/models/tables/warehouse_invoices.sql
+++ b/models/tables/warehouse_invoices.sql
@@ -66,4 +66,4 @@ left join {{ref('warehouse_invoice_shipment_aggregates')}} s on i.invoice_number
 left join {{ref('warehouse_base_accounts')}} a on i.customer_code = a.customer_code
 left join {{ref('revised_requested_delivery_date')}} rrdd on i.sales_order_number = rrdd.sales_order_number
 
-where nvl(ia.total_quantity,0) != 0
+where nvl(ia.total_quantity,0) != 0 or nvl(ia.total_extension,0) != 0


### PR DESCRIPTION
A change to adjust the logic for filtering out junk invoices.  Prior, the filter was taking out any invoices that had 0 total quantity, but due to forge updates, invoices that were all discounts can now have values but zero quantity, and have been filtered out.  This adjustment will add those negative values back in