### PR TITLE
changed weeks active calc to reflect second core invoice date 

### DIFF
--- a/models/tables/warehouse_accounts.sql
+++ b/models/tables/warehouse_accounts.sql
@@ -92,7 +92,7 @@ case
 	else NULL
 end as churn_date,
 
-datediff(week, aa.first_core_invoice_date, aa.most_recent_core_invoice_date) + 1 as weeks_active,
+datediff(week, aa.second_paid_coffee_invoice_date, aa.most_recent_core_invoice_date) + 1 as weeks_active,
 round((aa.total_coffee_extension / nullif(aa.total_coffee_weight, 0))::decimal(16,2),2) as average_coffee_price,
 
 coalesce(aaa.invested_machines,0) as invested_machines,


### PR DESCRIPTION
Since cohort date is based off of second core invoice date, Evan requested that we change the 'weeks active' calculation for wholesale accounts to also reflect this date. 

