### PR TITLE
filtering out SYSTEM warehouses

### DIFF
--- a/models/source/mapping/im_warehouse.sql
+++ b/models/source/mapping/im_warehouse.sql
@@ -14,5 +14,6 @@ case warehousedesc
 	else warehousedesc
 end as warehouse_name,
 warehousestate as warehouse_state,
-udf_palletspots as pallet_spots
+udf_palletspots as pallet_spots,
+udf_warehouse_type as warehouse_type
 from {{source('sage','im_warehouse')}} w

--- a/models/tables/warehouse_inventory_rollup.sql
+++ b/models/tables/warehouse_inventory_rollup.sql
@@ -14,8 +14,9 @@ with transaction_side as (
   from {{ref('im_item_transactions')}} t
     join {{ref('warehouse_products')}} p using (sku)
     join {{ref('gl_account')}} ai on p.inventory_gl_id = ai.id
+    join {{ref('im_warehouse')}} w using (warehouse_code)
     join analytics_finance.finance_calendar c on t.transaction_date = c.date
-  where c.fyear >= 2023
+  where c.fyear >= 2023 and w.warehouse_type != 'SYSTEM'
   group by 1, 2, 3, 4, 5, 6, 7
   ),
 


### PR DESCRIPTION
Warehouse type = system to filter out RMA warehouse from the transaction side of reconciliation. RMA is a holding/temp warehouse for returns that are scrapped in the field which means there is an item transaction logged but no matching GL transaction.