### PR TITLE
base_table_for_sub_unit_and_total_units_per_pack

### DIFF
--- a/models/base/warehouse_base_ssrtd_format.sql
+++ b/models/base/warehouse_base_ssrtd_format.sql
@@ -8,7 +8,7 @@ select
     f1.sub_unit_format_id,
     f1.units_in_pack,
     coalesce(f2.units_in_pack, 1) as sub_unit_units_in_pack,
-    coalesce(f1.units_in_pack * f2.units_in_pack, 1) as total_units_in_pack,
+    f1.units_in_pack * f1.sub_unit_units_in_pack, as total_units_in_pack,
     f1.stackable,
     f1.pallets_truck
 from

--- a/models/base/warehouse_base_ssrtd_format.sql
+++ b/models/base/warehouse_base_ssrtd_format.sql
@@ -1,0 +1,18 @@
+select 
+	f1.ssrtd_format_id,
+    f1.format_desc,
+    f1.case_eq,
+    f1.liquid_ounces,
+    f1.hi,
+    f1.ti,
+    f1.sub_unit_format_id,
+    f1.units_in_pack,
+    coalesce(nullif(f2.units_in_pack, 1), 1) as sub_unit_units_in_pack,
+    coalesce(nullif(f1.units_in_pack * f2.units_in_pack, 1), 1) as total_units_in_pack,
+    f1.stackable,
+    f1.pallets_truck
+from
+    {{ref('im_ssrtd_format')}} f1
+left join
+        {{ref('im_ssrtd_format')}} f2
+on f1.sub_unit_format_id = f2.ssrtd_format_id

--- a/models/base/warehouse_base_ssrtd_format.sql
+++ b/models/base/warehouse_base_ssrtd_format.sql
@@ -7,8 +7,8 @@ select
     f1.ti,
     f1.sub_unit_format_id,
     f1.units_in_pack,
-    coalesce(nullif(f2.units_in_pack, 1), 1) as sub_unit_units_in_pack,
-    coalesce(nullif(f1.units_in_pack * f2.units_in_pack, 1), 1) as total_units_in_pack,
+    coalesce(f2.units_in_pack, 1) as sub_unit_units_in_pack,
+    coalesce(f1.units_in_pack * f2.units_in_pack, 1) as total_units_in_pack,
     f1.stackable,
     f1.pallets_truck
 from

--- a/models/tables/warehouse_products.sql
+++ b/models/tables/warehouse_products.sql
@@ -77,6 +77,8 @@ select
 	ssrtd_format.ti as ssrtd_ti,
 	ssrtd_format.sub_unit_format_id as ssrtd_sub_unit_format_id,
 	ssrtd_format.units_in_pack as ssrtd_units_per_pack,
+	ssrtd_format.sub_unit_units_in_pack as ssrtd_sub_unit_units_per_pack,
+	ssrtd_format.total_units_in_pack as ssrtd_total_units_per_pack,
 	ssrtd_format.stackable as ssrtd_stackable,
 	ssrtd_format.pallets_truck as ssrtd_pallets_truck,
 
@@ -111,7 +113,7 @@ left join {{ref('gl_account')}} glp on pl.purchase_gl_id = glp.id
 left join {{ref('im_msrtd_flavor')}} msrtd_flavor using (msrtd_flavor_id)
 left join {{ref('im_msrtd_format')}} msrtd_format using (msrtd_format_id)
 left join {{ref('im_ssrtd_flavor')}} ssrtd_flavor using (ssrtd_flavor_id)
-left join {{ref('im_ssrtd_format')}} ssrtd_format using  (ssrtd_format_id)
+left join {{ref('warehouse_base_ssrtd_format')}} ssrtd_format using  (ssrtd_format_id)
 left join {{ref('im_ontap_flavor')}} ontap_flavor using  (ontap_flavor_id)
 left join {{ref('im_ontap_format')}} ontap_format using (ontap_format_id)
 left join {{ref('im_roasted_flavor')}} roasted_flavor using  (roasted_flavor_id)


### PR DESCRIPTION
warehouse_base_ssrtd_format, a self joined table to generate total_units_per_pack and sub_unit_units_per_pack. A dynamic way to calculate number of cans associated with rtd skus in consolidated.